### PR TITLE
Ensure version is stamped during publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## 0.16.2 (unreleased)
 
+### Improvements
+
+- Fix an issue where `pulumi` would issue a warning that the plugin version was incorrect.
+
 ## 0.16.1 (Released Novemeber 13th, 2018)
 
 ### Major Changes

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -17,7 +17,7 @@ if [ "$(go env GOOS)" = "windows" ]; then
 fi
 
 go build \
-   -ldflags "-X github.com/jen20/pulumi-vsphere/pkg/version.Version=${VERSION}" \
+   -ldflags "-X github.com/pulumi/pulumi-vsphere/pkg/version.Version=${VERSION}" \
    -o "${WORK_PATH}/pulumi-resource-vsphere${BIN_SUFFIX}" \
    "${ROOT}/cmd/pulumi-resource-vsphere"
 


### PR DESCRIPTION
When publishing, the ldflag we were passing to stamp in a version was
pointing at James' fork, leading to these warning when trying to use
the plugin:

```
warning: resource plugin vsphere is expected to have version
>=0.16.1, but has ; the wrong version may be on your path, or this may
be a bug in the plugin
```

In an ideal world, we would not need to hard code the import path of
the package, and that's something we can probably solve by using `go
list ./pkg/version` to solve across all repositories.

I opened an overall tracking issue to address the above.

Fixes #13